### PR TITLE
Added a unit test for class creditsWindow in main.py

### DIFF
--- a/tests_main/test_creditsWindow.py
+++ b/tests_main/test_creditsWindow.py
@@ -1,0 +1,49 @@
+import sys
+import os
+import pytest
+from PyQt5.QtWidgets import QApplication
+from unittest.mock import patch, MagicMock
+
+# Add the root directory to the system path before importing or patching 'main'
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+def mock_loadUi(ui_file, self):
+    # Set the attributes that are expected by creditsWindow
+    self.openBedrockSiteButton = MagicMock()
+    self.openBedrockSiteButton.clicked = MagicMock()
+    self.openGithubRepo = MagicMock()
+    self.openGithubRepo.clicked = MagicMock()
+
+# Patch loadUi before importing main
+with patch('PyQt5.uic.loadUi', side_effect=mock_loadUi):
+    # Mock the welcomeScreen class to bypass UI components
+    with patch('main.welcomeScreen', autospec=True):
+        from main import creditsWindow
+
+app = QApplication([])
+
+@pytest.fixture
+def credits_window():
+    return creditsWindow()
+
+@patch('subprocess.Popen')
+def test_open_bedrock_website(mock_popen, credits_window):
+    # Mock Popen so that no external commands run
+    mock_popen.return_value = MagicMock()
+    
+    # Invoke the method directly
+    credits_window.openBedrockWebsite()
+
+    # Assert that subprocess.Popen was called with the correct command
+    mock_popen.assert_called_once_with(['xdg-open', 'https://bedrocklinux.org/'])
+
+@patch('subprocess.Popen')
+def test_open_repo(mock_popen, credits_window):
+    # Mock Popen so that no external commands are run
+    mock_popen.return_value = MagicMock()
+
+    # Invoke the method directly
+    credits_window.openRepo()
+
+    # Assert that subprocess.Popen was called with the correct command
+    mock_popen.assert_called_once_with(['xdg-open', 'https://github.com/stratos-linux'])


### PR DESCRIPTION
Moved `mainScreen = welcomeScreen()` from global to inside of `main` function in `main.py` as `mainScreen` is already declared global inside of `main` function so it can still be use anywhere in the `main.py` code. Reason why I did this because while importing 'creditsWindow' in `test_creditsWindow.py` the line `mainScreen = welcomeScreen()` was getting executed as it was global, and it was causing trouble to run the unit test file.

edit: I created a copy of the cloned repo and in that I Moved `mainScreen = welcomeScreen()` from global to inside of `main` function. So now the `test_creditsWindow.py` won't work until `mainScreen = welcomeScreen()` So should I create a new PR now?